### PR TITLE
[minor] Keeping clear method compatible with other stores

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,6 +203,14 @@ FileStore.prototype.clear = function clear(fn) {
 
   var self = this;
 
+  if ('function' === typeof key) {
+
+    fn = key;
+    
+    key = null;
+
+  }
+
   fn = fn || noop;
 
   try {


### PR DESCRIPTION
@taronfoxworth got this awesome PR from https://github.com/cayasso/cacheman/pull/1 @harlanj
While there is no need for prefix in the clear method, I think its easier to remain compatible with all the other stores API this to avoid issues when switching in between stores for example programmatically, the pull request bellow will allow ignoring the prefix if its present.

Thanks!
JB
