### PR TITLE
Fix bug in cluster mode.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ FileStore.prototype.get = function get(key, fn) {
   if (Fs.existsSync(cacheFile)) {
     data = Fs.readFileSync(cacheFile);
     data = JSON.parse(data);
+    self.cache[key] = data.expire; //ensures cache sync in all clusters.
   } else {
     return fn(null, null);
   }

--- a/test/test-multi.js
+++ b/test/test-multi.js
@@ -1,0 +1,59 @@
+var assert = require('assert');
+var Path = require('path');
+var Fs = require('fs-extra');
+var sanitize = require('sanitize-filename');
+var Cache = require('../');
+
+describe('cacheman-file-multi', function() {
+  var cache1,
+    cache2;
+
+  before(function(done) {
+    cache1 = new Cache({
+      tmpDir: Path.join(process.cwd(), 'temp')
+    }, {});
+    cache2 = new Cache({
+      tmpDir: Path.join(process.cwd(), 'temp')
+    }, {});
+    done();
+  });
+  after(function(done) {
+    cache1.clear('test');
+    cache2.clear('test');
+    done();
+  });
+
+  it('should store items', function(done) {
+    cache1.set('test1', {
+      a: 1
+    }, function(err) {
+      if (err)
+        return done(err);
+      cache1.get('test1', function(err, data) {
+        if (err)
+          return done(err);
+        assert.equal(data.a, 1);
+        done();
+      });
+    });
+  });
+  it('should get stored items', function(done) {
+    cache1.get('test1', function(err, data) {
+      if (err)
+        return done(err);
+      assert.equal(data.a, 1);
+      cache2.get('test1', function(err, data) {
+        console.log(data);
+        if (err)
+          return done(err);
+        try {
+          assert.notEqual(data, null)
+          assert.equal(data.a, 1)
+          done()
+        } catch (e) {
+          done(e)
+        }
+      });
+    });
+  });
+});

--- a/test/test-multi.js
+++ b/test/test-multi.js
@@ -43,7 +43,6 @@ describe('cacheman-file-multi', function() {
         return done(err);
       assert.equal(data.a, 1);
       cache2.get('test1', function(err, data) {
-        console.log(data);
         if (err)
           return done(err);
         try {


### PR DESCRIPTION
Hi

this.cache is bind to a cluster, This means, if this.cache is updated on different cluster, key may not present in other clusters and hence returns an empty response. Consider I have two clusters, A and B 

A = B = OLD
A sets the new data and updates itself as A = NEW but B doesn't update since despite it is reading from file, it relying on this.cache key exist or not.

```
  if (Fs.existsSync(cacheFile)) {
    data = Fs.readFileSync(cacheFile);
    data = JSON.parse(data);
    console.log("LOGGED IN CACHEMAN")
    console.log(data) //Despite there is a data here.
  } else {
    return fn(null, null);
  }

  if (!this.cache[key]) {
    //returns just because this.cache is bind to a cluster.
    console.log("EMPTY CACHE OBJECT")
    return fn(null, null);
  }

```