### PR TITLE
Allow cache to be persistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REPORTER = spec
 
 test:
-	@./node_modules/.bin/mocha \
+	@/usr/bin/mocha \
 		--reporter $(REPORTER) \
 		--bail
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REPORTER = spec
 
 test:
-	@/usr/bin/mocha \
+	@./node_modules/.bin/mocha \
 		--reporter $(REPORTER) \
 		--bail
 

--- a/index.js
+++ b/index.js
@@ -41,13 +41,14 @@ FileStore.prototype.get = function get(key, fn) {
   if (Fs.existsSync(cacheFile)) {
     data = Fs.readFileSync(cacheFile);
     data = JSON.parse(data);
+    this.cache[key] = data.expire;	// added by MTP LLP - without this the cache is not persistent
   } else {
     return fn(null, null);
   }
 
-  if (!this.cache[key]) {
+  /*if (!this.cache[key]) {			// redundant test for a disk cache - could be removed
     return fn(null, null);
-  }
+  }*/
 
   if (!data) return fn(null, data);
   if (data.expire < Date.now()) {


### PR DESCRIPTION
Current release does not allow cache to persist across script invocations, because it tests self.cache{} membership before validating cache data expiry. This patch removes that test and updates the self.cache{} value from the disk file on each .get() request.