### PR TITLE
expires should be stored as a number

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ FileStore.prototype.set = function set(key, val, ttl, fn) {
   try {
     data = {
       value: JSON.stringify(val),
-      expire: JSON.stringify(Date.now() + ttl)
+      expire: Date.now() + ttl
     };
   } catch (e) {
     return fn(e);


### PR DESCRIPTION
It is compared to a number in get, without this patch it doesn't preserve the cache across processes